### PR TITLE
Start template project with Agent Shell.

### DIFF
--- a/scripts/mcp_server.cmd
+++ b/scripts/mcp_server.cmd
@@ -1,9 +1,0 @@
-@echo off
-setlocal
-
-set AGENT_APPLICATION=..
-set SPRING_PROFILES_ACTIVE=web,severance
-
-call .\support\agent.bat
-
-endlocal

--- a/scripts/mcp_server.sh
+++ b/scripts/mcp_server.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-export AGENT_APPLICATION=..
-export SPRING_PROFILES_ACTIVE=web,severance
-
-./support/agent.sh

--- a/scripts/shell.cmd
+++ b/scripts/shell.cmd
@@ -2,7 +2,6 @@
 setlocal
 
 set AGENT_APPLICATION=..
-set SPRING_PROFILES_ACTIVE=shell,severance
 
 call .\support\agent.bat
 

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 export AGENT_APPLICATION=..
-export SPRING_PROFILES_ACTIVE=shell,severance
 
 ./support/agent.sh

--- a/scripts/shell_docker.cmd
+++ b/scripts/shell_docker.cmd
@@ -1,9 +1,0 @@
-@echo off
-setlocal
-
-set AGENT_APPLICATION=..
-set SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
-
-call .\support\agent.bat
-
-endlocal

--- a/scripts/shell_docker.sh
+++ b/scripts/shell_docker.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-export AGENT_APPLICATION=..
-export SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
-
-./support/agent.sh

--- a/src/main/kotlin/com/embabel/template/ProjectNameApplication.kt
+++ b/src/main/kotlin/com/embabel/template/ProjectNameApplication.kt
@@ -17,8 +17,10 @@ package com.embabel.template
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import com.embabel.agent.config.annotation.EnableAgentShell
 
 @SpringBootApplication
+@EnableAgentShell
 class ProjectNameApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
This pull request removes legacy script configurations for various environments and introduces a new annotation to enable agent shell functionality in the main application. The most important changes include the removal of outdated `.cmd` and `.sh` scripts and the addition of the `@EnableAgentShell` annotation in the `ProjectNameApplication` class.

### Script cleanup:

I think, we should have separate template for MCP Server and not collocate with Shell.

### Application configuration:

* Added the `@EnableAgentShell` annotation in the `ProjectNameApplication` class to enable agent shell functionality, replacing the need for the removed scripts.