### PR TITLE
Make shell.sh invocable from the root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Add your magic here!
 Run the shell script to start Embabel under Spring Shell:
 
 ```bash
-cd scripts
-./shell.sh
+./scripts/shell.sh
 ```
 
 There is a single example agent, `WriteAndReviewAgent`.

--- a/scripts/shell.cmd
+++ b/scripts/shell.cmd
@@ -1,8 +1,10 @@
 @echo off
 setlocal
 
-set AGENT_APPLICATION=..
+set "script_dir=%~dp0"
 
-call .\support\agent.bat
+set AGENT_APPLICATION=%script_dir%..
+
+call "%script_dir%support\agent.bat"
 
 endlocal

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
-export AGENT_APPLICATION=..
+script_dir=$(dirname "$0")
 
-./support/agent.sh
+export AGENT_APPLICATION="${script_dir}/.."
+
+"$script_dir/support/agent.sh"


### PR DESCRIPTION
Currently, developers must switch to the scripts directory before invoking shell.sh, which is one extra command. Also, calling ./scripts/shell.sh fails due to the assumption that it is run in the scripts directory.

This change makes shell.sh/bat robust against the invoking directory.