### PR TITLE
Validate shell.cmd on Windows.

### DIFF
--- a/scripts/shell.cmd
+++ b/scripts/shell.cmd
@@ -1,10 +1,10 @@
 @echo off
 setlocal
 
-set "script_dir=%~dp0"
+set script_dir=%~dp0
 
 set AGENT_APPLICATION=%script_dir%..
 
-call "%script_dir%support\agent.bat"
+call %script_dir%support\agent.bat
 
 endlocal


### PR DESCRIPTION
This pull request makes minor adjustments to the `scripts/shell.cmd` file to improve readability and simplify syntax.

* Removed unnecessary quotes around the `script_dir` variable assignment. (`[scripts/shell.cmdL4-R8](diffhunk://#diff-c445a697c1fc22ba2630771a478474c7312402c29d00e8add410ac845336666dL4-R8)`)
* Simplified the `call` command by removing unnecessary quotes around the `script_dir` variable. (`[scripts/shell.cmdL4-R8](diffhunk://#diff-c445a697c1fc22ba2630771a478474c7312402c29d00e8add410ac845336666dL4-R8)`)