### PR TITLE
Add embabel-releases repo.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,16 @@
 
     <repositories>
         <repository>
+            <id>embabel-releases</id>
+            <url>https://repo.embabel.com/artifactory/libs-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>


### PR DESCRIPTION
This pull request makes a small configuration update to the Maven project. It adds a new repository to the `pom.xml` file to allow resolving release dependencies from Embabel's Artifactory.

- Added the `embabel-releases` repository to the `<repositories>` section in `pom.xml` to enable downloading release artifacts from Embabel's Artifactory.