### PR TITLE
Add notification steps for build success and failure

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,3 +35,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -U -B test verify
+
+  notify:
+    needs: [build]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
+    secrets: inherit
+    
+  notify-recovery:
+    needs: [build]
+    if: success() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/notify-recovery.yml@main
+    with:
+      branch: main
+    secrets: inherit


### PR DESCRIPTION
This pull request adds automated notifications to the workflow for the `main` branch, improving visibility into build failures and recoveries. Two new jobs have been introduced to send alerts to Discord when the build fails or when it recovers.

**Workflow notification enhancements:**

* Added a `notify` job that triggers on build failure for the `main` branch and sends a notification using the shared `discord-notify.yml` workflow.
* Added a `notify-recovery` job that triggers on build recovery (success after failure) for the `main` branch, using the shared `notify-recovery.yml` workflow and specifying the branch as `main`.